### PR TITLE
Add Raspberry Pi bootstrap and audit scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,56 @@
-- 👋 Hi, I’m @rfv-370
-- 👀 Coding since 1976 !
+# Raspberry Pi Fleet Bootstrap & Audit
 
-<!---
-rfv-370/rfv-370 is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.
-You can click the Preview link to take a look at your changes.
---->
+## System architecture and rationale
+
+Each Raspberry Pi boots from an internal SD card that hosts the primary OS and services. A USB stick holds periodic full clones made with `rpi-clone` for manual rollback. Devices reside behind a firewall and communicate over a ZeroTier VPN. Every 3‑5 years the fleet is rebuilt on a fresh OS image to avoid end‑of‑life and security exposure.
+
+## Upgrade and fallback philosophy
+
+Phase 1 is a physical swap: burn Raspberry Pi OS Bookworm to a new SD card, boot, then run the bootstrap script below. The USB clone remains a manual fallback. Phase 2 will add remote boot and automated rollback once local testing is complete.
+
+## Scripts
+
+### bootstrap.sh
+Configures a fresh system:
+- Enables and starts SSH
+- Installs ZeroTier and joins a network if `ZT_NETWORK_ID` is set
+- Installs WayVNC for remote desktop (RealVNC Server is no longer bundled but can be installed manually)
+- Installs common tools: cron, curl, wget, vim, git, htop, etc.
+- Runs `apt update` and `apt full-upgrade -y`
+- Sets up unattended upgrades with automatic reboot when required
+- Adds a monthly reboot via cron on the 5th at 03:00
+- Ensures `systemd-timesyncd` keeps the clock in sync
+- Logs actions to stdout and `/var/log/bootstrap.log`
+
+Run with root privileges:
+```sh
+sudo ./bootstrap.sh
+```
+Optional variables:
+- `ZT_NETWORK_ID` – ZeroTier network to join
+- `VNC_PASSWORD` – password for WayVNC (random if unset)
+
+### audit.sh
+Captures system state and user data:
+- Lists installed APT packages
+- Lists enabled and running systemd services
+- Dumps crontabs for users with UID ≥ 1000
+- Inventories users, home directories, shells, dotfiles, and paths under `~/.ssh/` and `~/.config/`
+- Writes JSON report to `/tmp/system_audit_*.json`
+- Creates per‑user tarballs of dotfiles and `~/.ssh/` under `/tmp/gesser_user_backups`
+
+Run with root privileges:
+```sh
+sudo ./audit.sh
+```
+
+## Output structure
+- `/var/log/bootstrap.log` – log from `bootstrap.sh`
+- `/tmp/system_audit_<timestamp>.json` – audit report
+- `/tmp/gesser_user_backups/USERNAME_backup.tgz` – per‑user archives
+
+## Known caveats
+- ZeroTier install uses an external script and requires Internet access
+- WayVNC password is printed during setup; change it if needed
+- If a user lacks `.ssh/` or `.config/`, the audit will note empty lists
+- RealVNC Server can still be installed separately but currently requires an X11 session

--- a/audit.sh
+++ b/audit.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+set -euo pipefail
+
+log() { echo "$(date -Iseconds) $*"; }
+
+OUTPUT_FILE="/tmp/system_audit_$(date +%Y%m%d%H%M%S).json"
+BACKUP_DIR="/tmp/gesser_user_backups"
+mkdir -p "$BACKUP_DIR"
+chmod 700 "$BACKUP_DIR"
+
+log "Gathering package list"
+dpkg-query -W -f='${Package} ${Version}\n' | sort > /tmp/apt_packages.txt
+
+log "Gathering enabled services"
+systemctl list-unit-files --type=service --state=enabled --no-legend | awk '{print $1}' | sort > /tmp/enabled_services.txt
+
+log "Gathering running services"
+systemctl list-units --type=service --state=running --no-legend | awk '{print $1}' | sort > /tmp/running_services.txt
+
+USER_JSONL=/tmp/user_data.jsonl
+: > "$USER_JSONL"
+
+for user in $(awk -F: '$3 >= 1000 && $1 != "nobody" {print $1}' /etc/passwd); do
+  home=$(eval echo "~$user")
+  shell=$(getent passwd "$user" | cut -d: -f7)
+
+  dotfiles_list=$(for f in .bashrc .profile .gitconfig; do [ -f "$home/$f" ] && printf '%s\n' "$f"; done)
+  dotfiles_json=$(printf '%s\n' "$dotfiles_list" | python3 -c 'import sys,json; print(json.dumps([l.strip() for l in sys.stdin if l.strip()]))')
+
+  ssh_paths=$(find "$home/.ssh" -mindepth 1 -maxdepth 5 2>/dev/null | sed "s|$home/||")
+  ssh_json=$(printf '%s\n' "$ssh_paths" | python3 -c 'import sys,json; print(json.dumps([l.strip() for l in sys.stdin if l.strip()]))')
+
+  config_paths=$(find "$home/.config" -mindepth 1 -maxdepth 5 2>/dev/null | sed "s|$home/||")
+  config_json=$(printf '%s\n' "$config_paths" | python3 -c 'import sys,json; print(json.dumps([l.strip() for l in sys.stdin if l.strip()]))')
+
+  cron_content=$(crontab -l -u "$user" 2>/dev/null || true)
+  cron_json=$(printf '%s' "$cron_content" | python3 -c 'import sys,json; print(json.dumps(sys.stdin.read()))')
+
+  tarball="$BACKUP_DIR/${user}_backup.tgz"
+  tar czf "$tarball" -C "$home" $(for f in .bashrc .profile .gitconfig .ssh; do [ -e "$home/$f" ] && echo "$f"; done) 2>/dev/null || true
+  chmod 600 "$tarball"
+
+  USER_NAME="$user" HOME_DIR="$home" USER_SHELL="$shell" DOTFILES="$dotfiles_json" SSH_PATHS="$ssh_json" CONFIG_PATHS="$config_json" CRON="$cron_json" \
+  python3 - <<'PY'
+import os, json
+print(json.dumps({
+  "username": os.environ["USER_NAME"],
+  "home": os.environ["HOME_DIR"],
+  "shell": os.environ["USER_SHELL"],
+  "dotfiles": json.loads(os.environ["DOTFILES"]),
+  "ssh_paths": json.loads(os.environ["SSH_PATHS"]),
+  "config_paths": json.loads(os.environ["CONFIG_PATHS"]),
+  "crontab": json.loads(os.environ["CRON"])
+}))
+PY >> "$USER_JSONL"
+
+done
+
+python3 - <<'PY'
+import json, pathlib
+with open('/tmp/apt_packages.txt') as f:
+    packages=[line.strip() for line in f if line.strip()]
+with open('/tmp/enabled_services.txt') as f:
+    enabled=[line.strip() for line in f if line.strip()]
+with open('/tmp/running_services.txt') as f:
+    running=[line.strip() for line in f if line.strip()]
+with open('/tmp/user_data.jsonl') as f:
+    users=[json.loads(line) for line in f if line.strip()]
+with open("$OUTPUT_FILE","w") as f:
+    json.dump({
+        "packages": packages,
+        "enabled_services": enabled,
+        "running_services": running,
+        "users": users
+    }, f, indent=2)
+PY
+
+chmod 600 "$OUTPUT_FILE"
+log "Audit saved to $OUTPUT_FILE"
+log "User backups stored in $BACKUP_DIR"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+set -euo pipefail
+
+LOG_FILE="/var/log/bootstrap.log"
+log() {
+  echo "$(date -Iseconds) $*" | tee -a "$LOG_FILE"
+}
+
+[ "$EUID" -eq 0 ] || { echo "Run as root"; exit 1; }
+
+log "Updating package lists"
+apt-get update -y
+
+log "Performing full upgrade"
+apt-get full-upgrade -y
+
+log "Installing base packages"
+apt-get install -y openssh-server cron curl wget vim git htop unattended-upgrades wayvnc
+
+log "Enabling and starting SSH"
+systemctl enable ssh
+systemctl start ssh
+
+log "Installing ZeroTier"
+if ! command -v zerotier-cli >/dev/null 2>&1; then
+  curl -fsSL https://install.zerotier.com | bash
+fi
+systemctl enable zerotier-one
+systemctl start zerotier-one
+if [ -n "${ZT_NETWORK_ID:-}" ]; then
+  zerotier-cli join "$ZT_NETWORK_ID" || true
+fi
+
+DEFAULT_USER=$(awk -F: '$3>=1000 && $1!="nobody" {print $1; exit}' /etc/passwd)
+if [ -n "$DEFAULT_USER" ]; then
+  VNC_PASS=${VNC_PASSWORD:-$(tr -dc 'A-Za-z0-9' </dev/urandom | head -c12)}
+  log "Configuring wayvnc for user $DEFAULT_USER with password $VNC_PASS"
+  sudo -u "$DEFAULT_USER" mkdir -p "/home/$DEFAULT_USER/.config/wayvnc"
+  sudo -u "$DEFAULT_USER" tee "/home/$DEFAULT_USER/.config/wayvnc/config" >/dev/null <<CONF
+address=0.0.0.0
+rfb_port=5900
+password=$VNC_PASS
+CONF
+  chmod 600 "/home/$DEFAULT_USER/.config/wayvnc/config"
+  systemctl enable "wayvnc@$DEFAULT_USER.service"
+  systemctl start "wayvnc@$DEFAULT_USER.service"
+fi
+
+log "Configuring unattended upgrades"
+cat >/etc/apt/apt.conf.d/20auto-upgrades <<'CONF'
+APT::Periodic::Update-Package-Lists "1";
+APT::Periodic::Unattended-Upgrade "1";
+CONF
+if ! grep -q 'Unattended-Upgrade::Automatic-Reboot' /etc/apt/apt.conf.d/50unattended-upgrades 2>/dev/null; then
+cat >>/etc/apt/apt.conf.d/50unattended-upgrades <<'CONF'
+Unattended-Upgrade::Automatic-Reboot "true";
+Unattended-Upgrade::Automatic-Reboot-Time "02:00";
+CONF
+fi
+
+log "Adding monthly reboot cron job"
+( crontab -l 2>/dev/null; echo "0 3 5 * * /sbin/shutdown -r now" ) | crontab -
+
+log "Enabling systemd-timesyncd"
+timedatectl set-ntp true
+
+log "Bootstrap completed"


### PR DESCRIPTION
## Summary
- add bootstrap.sh to configure a fresh Raspberry Pi OS install (SSH, ZeroTier, WayVNC, upgrades, cron, time sync)
- add audit.sh to snapshot packages, services, users, dotfiles and create backups
- document architecture, upgrade philosophy and script usage in README

## Testing
- `bash -n bootstrap.sh audit.sh`
- `shellcheck bootstrap.sh audit.sh` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a09fd9b0248321ac2ef732ada5947c